### PR TITLE
Inertial velocity

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Server.Shuttles.Components
         /// <summary>
         /// Thrust gets multiplied by this value if it's for braking.
         /// </summary>
-        public const float BrakeCoefficient = 1.5f;
+        public const float BrakeCoefficient = 0.5f;
 
         /// <summary>
         /// Maximum velocity assuming unupgraded, tier 1 thrusters
@@ -66,9 +66,9 @@ namespace Content.Server.Shuttles.Components
         /// Damping applied to the shuttle's physics component when not in FTL.
         /// </summary>
         [DataField("linearDamping"), ViewVariables(VVAccess.ReadWrite)]
-        public float LinearDamping = 0.05f;
+        public float LinearDamping = 0.005f;
 
         [DataField("angularDamping"), ViewVariables(VVAccess.ReadWrite)]
-        public float AngularDamping = 0.05f;
+        public float AngularDamping = 0.005f;
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Снизил потерю инерционной скорости, а так же скорость торможения
## Why / Balance
Зачем? В космосе нету сопротивления воздуха, тормозить нечему(Снизил не до нуля что бы шаттл не улетал в ебеня)

## How to test
Тестил на локалке, работает

## Media
Извиняюсь за качество и водяной знак, пришлось что-бы видос грузился
https://github.com/Corvax-Frontier/corvax-frontier-14/assets/129673445/44dabe75-481a-44de-ad00-392eb2660bda
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

- tweak: Changed inertial velocity