### PR TITLE
Fix Vending Machines

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -175,6 +175,7 @@ namespace Content.Server.VendingMachines
         private void OnBreak(EntityUid uid, VendingMachineComponent vendComponent, BreakageEventArgs eventArgs)
         {
             vendComponent.Broken = true;
+            _userInterfaceSystem.CloseUi(uid, VendingMachineUiKey.Key);
             TryUpdateVisualState(uid, vendComponent);
             EnsureComp<WeldableComponent>(uid);
         }


### PR DESCRIPTION
## About the PR
Хитрые, скупые и невероятно жадные торговые автоматы NanoTrasen любили обманывать честных работяг на крупные суммы денег. Но этому настал конец, более ни один автомат никого не обманет.
P.S. Было проверено на локальном сервере, но видео записи нет

**Changelog**
- Исправлена ошибка при которой сломанные автоматы списывали деньги https://discord.com/channels/1222332535628103750/1250118619585576960/1250118619585576960